### PR TITLE
Added support for Organizr

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -137,7 +137,26 @@ services:
       - "traefik.frontend.rule=Host:jackett.${DOMAIN_NAME}"
       - "traefik.port=9117"
       - "traefik.docker.network=web"
-
+  
+  organizr:
+    image: lsiocommunity/organizr
+    container_name: organizr
+    #restart: always
+    ports:
+      - "80:80"
+    networks:
+      - web
+    environment:
+      - PUID=${USER_ID}
+      - PGID=${GROUP_ID}
+    volumes:
+      - ./media/organizr/config:/config
+    labels:
+      - "traefik.enable=true"
+      - "traefik.backend=organizr"
+      - "traefik.frontend.rule=Host:organizr.${DOMAIN_NAME}"
+      - "traefik.port=80"
+      - "traefik.docker.network=web"
 networks:
   web:
     external:


### PR DESCRIPTION
Feature: #14 
Organizr:
About

Do you have quite a bit of services running on your computer or server? Do you have a lot of bookmarks or have to memorize a bunch of ip's and ports? Well, Organizr is here to help with that. Organizr allows you to setup "Tabs" that will be loaded all in one webpage. You can then work on your server with ease. You can even open up two tabs side by side. Want to give users access to some Tabs? No problem, just enable user support and have them make an account. Want guests to be able to visit too? Enable Guest support for those tabs.